### PR TITLE
add support for double quotes and some minor fixes

### DIFF
--- a/bib.py
+++ b/bib.py
@@ -108,7 +108,7 @@ def find_block(data, i, list_block):
 def find_subblock_end(block, i):
     if len(block) == i:
         return i - 1
-    if block[i][-2:] == '},':
+    if block[i][-2:] == '},' or block[i][-2:] == '",':
         return i
     else:
         return find_subblock_end(block, i + 1)
@@ -121,14 +121,17 @@ def find_subblock(block, i, list_subblock):
 
     idx = block[i].find('=');
     if idx != -1:
-
         idx2 = block[i].find('{');
         if idx2 != -1:
             end = find_subblock_end(block, i)
         else:
-            end = i
+            idx2 = block[i].find('"');
+            if idx2 != -1:
+            	end = find_subblock_end(block, i)
+            else:
+            	end = i
         list_subblock.append([i,end,idx])
-        return find_subblock(block, end+1 , list_subblock)
+        return find_subblock(block, end+1, list_subblock)
     else:
         print(Red("this should not happen"))
         return list_subblock;
@@ -367,6 +370,7 @@ def parse_arguments():
         config['purify'] = args.purify
         config['output'] = args.output if args.output != '' else config['input']
         config['dry_run'] = args.dry_run
+        config['list-duplicates'] = args.list_duplicates
     else:
         v = args.verbose
         tmp = input('Enable verbose mode [{}]? '.format('Y/n' if v else 'y/N'))
@@ -386,6 +390,9 @@ def parse_arguments():
         v = args.dry_run
         tmp = input('Dry-run [{}]? '.format('Y/n' if v else 'y/N'))
         config['dry_run'] = str2bool(tmp if tmp != '' else ('Y' if v else 'n'))
+        v = args.list_duplicates
+        tmp = input('List duplicates [{}]? '.format('Y/n' if v else 'y/N'))
+        config['list-duplicates'] = str2bool(tmp if tmp != '' else ('Y' if v else 'n'))
 
         fn = args.output if args.output != '' else config['input']
         fn = input('Output file [{}]:'.format(fn))
@@ -441,6 +448,6 @@ def main():
         print(s)
 
     if config['list-duplicates']:
-        list_duplicate_referer(blocks);
+    	list_duplicate_referer(blocks);
 
 main();

--- a/collection.bib
+++ b/collection.bib
@@ -179,6 +179,18 @@
   note           = {\url{https://eprint.iacr.org/2017/212}},
 }
 
+@misc{cryptoeprint:2020:012,
+
+  author         = "Erdem Alkim and
+                    Yusuf Alper Bilgin and
+                    Murat Cenk and
+                    Fran\c{c}ois G\'erard",
+  title          = "{Cortex-M4} Optimizations for \{R,M\}{LWE} Schemes",
+  howpublished   = "Cryptology ePrint Archive, Report 2020/012",
+  year           = "2020",
+  note           = "\url{https://eprint.iacr.org/2020/012}",
+}
+
 @inproceedings{fiat-crypto,
   author         = {Andres Erbsen and
                     Jade Philipoom and


### PR DESCRIPTION
Hello,

First of all, thanks for this nice work. This pull request includes the support for double quotes. It is stated [here](https://nwalsh.com/tex/texhelp/bibtx-6.html) that: 
>  The text of a field is a string of characters, with no unmatched braces, surrounded by either a pair of braces or a pair of '"' characters. 